### PR TITLE
Migrate to XML::Struct

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -18,7 +18,7 @@ my $builder = Module::Build->new(
         'perl' => '5.10.1',
         'Catmandu' => '0.0302',
         'Furl' => '0.41',
-        'XML::LibXML::Simple' => '0.91',
+        'XML::Struct' => '0.16',
         'Moo' => '1.000003',
     },
     add_to_cleanup => [qw(

--- a/t/xml.t
+++ b/t/xml.t
@@ -12,14 +12,25 @@ is(Catmandu::Importer::SRU->new(%options)->each(sub {
     like $_[0]->{recordData}->{dc}->{title}, qr/ Title/, 'got record';
 }), 2);
 
-$options{recordTag} = 'dc';
-
-is(Catmandu::Importer::SRU->new(%options)->each(sub { 
+is(Catmandu::Importer::SRU->new(%options, recordTag => 'dc')->each(sub { 
     like $_[0]->{title}, qr/ Title/, 'got record';
 }), 2);
 
+my $record = Catmandu::Importer::SRU->new(%options, recordTag => 'dc')->first;
+ok $record->{date}, 'don\'t include recordData (simple, recordTag)';
+
+$record = Catmandu::Importer::SRU->new(%options)->first;
+is ref $record->{recordData}, 'HASH', 'include recordData (simple, !recordTag)';
+
+$record = Catmandu::Importer::SRU->new(%options, xml => 'struct')->first;
+is $record->[0]->[0], 'dc', 'record as array of elements (struct, !recordTag)';
+
+$record = Catmandu::Importer::SRU->new(%options, xml => 'struct', recordTag => 1)->first;
+is $record->[0], 'dc', 'record as element (struct, recordTag)';
+
 done_testing;
 
+# returns an XML document, given as query, from directory t/
 package MockFurl;
 use Moo;
 use Furl::Response;


### PR DESCRIPTION
As discussed in https://github.com/LibreCat/Catmandu-SRU/issues/3 this does not force an array on `record` elements, so the change is not fully backwards compatible. One could provide other configuration values to `xml`, for instance to get raw DOM objects or XML strings.
