### PR TITLE
fix handling of XML namespaces

### DIFF
--- a/lib/Catmandu/Importer/SRU.pm
+++ b/lib/Catmandu/Importer/SRU.pm
@@ -103,7 +103,7 @@ sub _hashify {
   if ($xc->exists('/srw:searchRetrieveResponse/srw:records')) {
       $records->{record} = [];
 
-      for ($xc->findnodes('/srw:searchRetrieveResponse/srw:records//srw:record')) {
+      for ($xc->findnodes('/srw:searchRetrieveResponse/srw:records/srw:record')) {
         my $recordSchema   = $xc->findvalue('./srw:recordSchema',$_);
         my $recordPacking  = $xc->findvalue('./srw:recordPacking',$_);
         my $recordData     = '' . $xc->find('./srw:recordData/*',$_)->pop();

--- a/t/marcxml_ns.xml
+++ b/t/marcxml_ns.xml
@@ -1,0 +1,55 @@
+<?xml version='1.0'?>
+
+<searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+<version>1.1</version>
+<numberOfRecords>4</numberOfRecords>
+<records>
+<record><recordSchema>info:srw/schema/1/marcxml-v1.1</recordSchema><recordPacking>xml</recordPacking><recordData>
+<record type="Bibliographic">
+  <leader>00785nas a2200277 c 4500</leader>
+  <controlfield tag="001">987874829</controlfield>
+  <datafield ind1="1" ind2="0" tag="245">
+    <subfield code="a">Code4Lib journal</subfield>
+    <subfield code="h">Elektronische Ressource</subfield>
+    <subfield code="b">C4LJ</subfield>
+  </datafield>
+</record>
+</recordData><recordPosition>1</recordPosition></record>
+<record><recordSchema>info:srw/schema/1/marcxml-v1.1</recordSchema><recordPacking>xml</recordPacking><recordData>
+<record type="Bibliographic" xmlns:slim="http://www.loc.gov/MARC21/slim">
+  <leader>00785nas a2200277 c 4500</leader>
+  <controlfield tag="001">987874829</controlfield>
+  <datafield ind1="1" ind2="0" tag="245">
+    <subfield code="a">Code4Lib journal</subfield>
+    <subfield code="h">Elektronische Ressource</subfield>
+    <subfield code="b">C4LJ</subfield>
+  </datafield>
+</record>
+</recordData><recordPosition>2</recordPosition></record>
+<record><recordSchema>info:srw/schema/1/marcxml-v1.1</recordSchema><recordPacking>xml</recordPacking><recordData>
+<slim:record type="Bibliographic" xmlns:slim="http://www.loc.gov/MARC21/slim">
+  <slim:leader>00785nas a2200277 c 4500</slim:leader>
+  <slim:controlfield tag="001">987874829</slim:controlfield>
+  <slim:datafield ind1="1" ind2="0" tag="245">
+    <slim:subfield code="a">Code4Lib journal</slim:subfield>
+    <slim:subfield code="h">Elektronische Ressource</slim:subfield>
+    <slim:subfield code="b">C4LJ</slim:subfield>
+  </slim:datafield>
+</slim:record>
+</recordData><recordPosition>3</recordPosition></record>
+<record><recordSchema>info:srw/schema/1/marcxml-v1.1</recordSchema><recordPacking>xml</recordPacking><recordData>
+<marc:record type="Bibliographic" xmlns:marc="http://www.loc.gov/MARC21/slim">
+  <marc:leader>00785nas a2200277 c 4500</marc:leader>
+  <marc:controlfield tag="001">987874829</marc:controlfield>
+  <marc:datafield ind1="1" ind2="0" tag="245">
+    <marc:subfield code="a">Code4Lib journal</marc:subfield>
+    <marc:subfield code="h">Elektronische Ressource</marc:subfield>
+    <marc:subfield code="b">C4LJ</marc:subfield>
+  </marc:datafield>
+</marc:record>
+</recordData><recordPosition>4</recordPosition></record>
+</records>
+
+<extraResponseData></extraResponseData> 
+<echoedSearchRetrieveRequest><version>1.1</version><query>code4lib</query><startRecord>1</startRecord><maximumRecords>10</maximumRecords><recordSchema>marcxml</recordSchema><xQuery><searchClause xmlns="http://www.loc.gov/zing/cql/xcql/"><index>srw.ServerChoice</index><relation><value>scr</value></relation><term>code4lib</term></searchClause></xQuery></echoedSearchRetrieveRequest>
+</searchRetrieveResponse>

--- a/t/namespace.t
+++ b/t/namespace.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Catmandu::Importer::SRU;
+use Catmandu::Importer::SRU::Parser::marcxml;
+require 't/lib/MockFurl.pm';
+
+my %attrs = (
+    base => 'http://www.unicat.be/sru',
+    query => 'marcxml_ns.xml',
+    recordSchema => 'marcxml',
+    parser => 'marcxml',
+    furl => MockFurl->new,
+);
+
+my $importer = Catmandu::Importer::SRU->new(%attrs);
+my $records = $importer->to_array();
+for my $record ( @{$records} ) {
+    ok (exists $record->{_id}, 'marc has _id');
+    ok (exists $record->{record}, 'marc has record');
+    is_deeply ($record->{record}->[0], ['LDR', ' ', ' ', '_', '00785nas a2200277 c 4500'], 'marc has leader');
+    is_deeply ($record->{record}->[1], ['001', ' ', ' ', '_', '987874829'], 'marc has controlfield');
+    is_deeply ($record->{record}->[-1], ['245', '1', '0', 'a', 'Code4Lib journal', 'h', 'Elektronische Ressource', 'b', 'C4LJ'], 'marc has datafield');
+}
+
+done_testing;


### PR DESCRIPTION
Add better support for namespace prefixes. Now parser marcxml.pm can handle records with prefixes like "slim:record" or "marc:record". 

Files changed/added:
- marcxml.pm: ignore namespaces, use of "getChildrenByLocalName()" to get child nodes
- SRU.pm
- marcxml_ns.xml: sample record with different prefixes
- namespaces.t
