### PR TITLE
Add support for namespace prefixes

### DIFF
--- a/lib/Catmandu/Importer/SRU/Parser/marcxml.pm
+++ b/lib/Catmandu/Importer/SRU/Parser/marcxml.pm
@@ -34,6 +34,11 @@ sub parse {
 
   my $xml = $record->{recordData};
 
+  my $ns = $1 if $xml =~ m/^<(.*):record>/;
+  if ($ns) {
+    $xml =~ s|<$ns:record>|<$ns:record xmlns:$ns="http://www.loc.gov/MARC21/slim">|;
+  }
+
 	my $parser = XML::LibXML->new();
   my $doc    = $parser->parse_string($xml);
   my $root   = $doc->documentElement;

--- a/t/files/marcxml_ns_prefix.xml
+++ b/t/files/marcxml_ns_prefix.xml
@@ -1,0 +1,524 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+
+  <zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/" xmlns:marc="http://www.loc.gov/MARC21/slim" >
+    <zs:version>1.1</zs:version>
+    <zs:numberOfRecords>79446</zs:numberOfRecords>
+    <zs:records>
+        <zs:record>
+          <zs:recordPacking>xml</zs:recordPacking>
+          <zs:recordData>
+              	<marc:record>
+		<marc:leader>00000ndd a2200000 u 4500</marc:leader>
+		<marc:controlfield tag="001">004641415</marc:controlfield>
+		<marc:controlfield tag="003">DE-633</marc:controlfield>
+		<marc:controlfield tag="005">20161205081635.0</marc:controlfield>
+		<marc:datafield tag="031" ind1=" " ind2=" ">
+			<marc:subfield code="a">1</marc:subfield>
+			<marc:subfield code="b">1</marc:subfield>
+			<marc:subfield code="c">1</marc:subfield>
+			<marc:subfield code="d">[without title].</marc:subfield>
+			<marc:subfield code="g">F-4</marc:subfield>
+			<marc:subfield code="m">V</marc:subfield>
+			<marc:subfield code="n">bBEA</marc:subfield>
+			<marc:subfield code="o">3/4</marc:subfield>
+			<marc:subfield code="p">,8GAG/4.G8DEC/4D8-</marc:subfield>
+			<marc:subfield code="r">E|b</marc:subfield>
+			<marc:subfield code="t">Wer nie sein Brot mit Tränen aß</marc:subfield>
+			<marc:subfield code="u">20042863</marc:subfield>
+			<marc:subfield code="2">pe</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="040" ind1=" " ind2=" ">
+			<marc:subfield code="a">DE-633</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="041" ind1=" " ind2=" ">
+			<marc:subfield code="a">ger</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="100" ind1="1" ind2=" ">
+			<marc:subfield code="a">Zelter, Carl Friedrich</marc:subfield>
+			<marc:subfield code="d">1758-1832</marc:subfield>
+			<marc:subfield code="0">98629</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="240" ind1="1" ind2="0">
+			<marc:subfield code="a">Wer nie sein Brot mit Tränen aß</marc:subfield>
+			<marc:subfield code="m">V</marc:subfield>
+			<marc:subfield code="r">E|b</marc:subfield>
+			<marc:subfield code="0">3917680</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="245" ind1="1" ind2="0">
+			<marc:subfield code="a">[without title]</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="300" ind1=" " ind2=" ">
+			<marc:subfield code="a">score: 1p. [p. 3]</marc:subfield>
+			<marc:subfield code="c">34 x 21 cm</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="500" ind1=" " ind2=" ">
+			<marc:subfield code="a">Einsystemige Skizze von Zelters Hand mit Blei auf den Text &quot;Wer nie sein Brot mit Tränen aß&quot;.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="592" ind1=" " ind2=" ">
+			<marc:subfield code="a">[letters in circle, countermark letters (not to identify)]</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="593" ind1=" " ind2=" ">
+			<marc:subfield code="a">Autograph manuscript</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="b">B</marc:subfield>
+			<marc:subfield code="c">1</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="a">B</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="650" ind1="0" ind2="0">
+			<marc:subfield code="a">Lieder</marc:subfield>
+			<marc:subfield code="0">25227</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="700" ind1="1" ind2=" ">
+			<marc:subfield code="a">Goethe, Johann Wolfgang von</marc:subfield>
+			<marc:subfield code="d">1749-1832</marc:subfield>
+			<marc:subfield code="j">Ascertained</marc:subfield>
+			<marc:subfield code="0">173930</marc:subfield>
+			<marc:subfield code="4">lyr</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="773" ind1="0" ind2=" ">
+			<marc:subfield code="w">464141752</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="852" ind1=" " ind2=" ">
+			<marc:subfield code="a">D-B</marc:subfield>
+			<marc:subfield code="c">Mus.ms.autogr. Zelter, K. F. 17 (3)</marc:subfield>
+			<marc:subfield code="e">Staatsbibliothek zu Berlin - Preußischer Kulturbesitz, Musikabteilung</marc:subfield>
+			<marc:subfield code="x">30000655</marc:subfield>
+		</marc:datafield>
+	</marc:record>
+
+          </zs:recordData>
+          <zs:recordPosition>1</zs:recordPosition>
+        </zs:record>
+        <zs:record>
+          <zs:recordPacking>xml</zs:recordPacking>
+          <zs:recordData>
+              	<marc:record>
+		<marc:leader>00000ndd a2200000 u 4500</marc:leader>
+		<marc:controlfield tag="001">004641416</marc:controlfield>
+		<marc:controlfield tag="003">DE-633</marc:controlfield>
+		<marc:controlfield tag="005">20161205081635.0</marc:controlfield>
+		<marc:datafield tag="031" ind1=" " ind2=" ">
+			<marc:subfield code="a">1</marc:subfield>
+			<marc:subfield code="b">1</marc:subfield>
+			<marc:subfield code="c">1</marc:subfield>
+			<marc:subfield code="d">Andantino.</marc:subfield>
+			<marc:subfield code="g">G-2</marc:subfield>
+			<marc:subfield code="m">V</marc:subfield>
+			<marc:subfield code="n">bBEA</marc:subfield>
+			<marc:subfield code="o">2/4</marc:subfield>
+			<marc:subfield code="p">&#39;{6CE}/8GGG&#39;&#39;C/&#39;GGG&#39;&#39;C/&#39;nBG&#39;&#39;C&#39;C/</marc:subfield>
+			<marc:subfield code="r">c</marc:subfield>
+			<marc:subfield code="t">Es war ein Kind das wollte nie</marc:subfield>
+			<marc:subfield code="u">20042865</marc:subfield>
+			<marc:subfield code="2">pe</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="040" ind1=" " ind2=" ">
+			<marc:subfield code="a">DE-633</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="041" ind1=" " ind2=" ">
+			<marc:subfield code="a">ger</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="100" ind1="1" ind2=" ">
+			<marc:subfield code="a">Zelter, Carl Friedrich</marc:subfield>
+			<marc:subfield code="d">1758-1832</marc:subfield>
+			<marc:subfield code="0">98629</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="240" ind1="1" ind2="0">
+			<marc:subfield code="a">Die wackelnde Glocke</marc:subfield>
+			<marc:subfield code="m">V, pf</marc:subfield>
+			<marc:subfield code="r">c</marc:subfield>
+			<marc:subfield code="0">3917682</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="245" ind1="1" ind2="0">
+			<marc:subfield code="a">[caption title, p. 4:] Die wackelnde Glocke [right:] B. 5. Januar 1814.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="260" ind1=" " ind2=" ">
+			<marc:subfield code="c">1814</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="300" ind1=" " ind2=" ">
+			<marc:subfield code="a">score: 1p. [p. 4]</marc:subfield>
+			<marc:subfield code="c">34 x 21 cm</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="592" ind1=" " ind2=" ">
+			<marc:subfield code="a">[letters in circle, countermark letters (not to identify)]</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="593" ind1=" " ind2=" ">
+			<marc:subfield code="a">Autograph manuscript</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="b">V</marc:subfield>
+			<marc:subfield code="c">1</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="b">pf</marc:subfield>
+			<marc:subfield code="c">1</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="a">V, pf</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="650" ind1="0" ind2="0">
+			<marc:subfield code="a">Lieder</marc:subfield>
+			<marc:subfield code="0">25227</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="700" ind1="1" ind2=" ">
+			<marc:subfield code="a">Goethe, Johann Wolfgang von</marc:subfield>
+			<marc:subfield code="d">1749-1832</marc:subfield>
+			<marc:subfield code="j">Ascertained</marc:subfield>
+			<marc:subfield code="0">173930</marc:subfield>
+			<marc:subfield code="4">lyr</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="730" ind1="0" ind2=" ">
+			<marc:subfield code="a">Es war ein Kind das wollte nie</marc:subfield>
+			<marc:subfield code="g">RISM</marc:subfield>
+			<marc:subfield code="0">3917681</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="773" ind1="0" ind2=" ">
+			<marc:subfield code="w">464141752</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="852" ind1=" " ind2=" ">
+			<marc:subfield code="a">D-B</marc:subfield>
+			<marc:subfield code="c">Mus.ms.autogr. Zelter, K. F. 17 (4)</marc:subfield>
+			<marc:subfield code="e">Staatsbibliothek zu Berlin - Preußischer Kulturbesitz, Musikabteilung</marc:subfield>
+			<marc:subfield code="x">30000655</marc:subfield>
+		</marc:datafield>
+	</marc:record>
+
+          </zs:recordData>
+          <zs:recordPosition>2</zs:recordPosition>
+        </zs:record>
+        <zs:record>
+          <zs:recordPacking>xml</zs:recordPacking>
+          <zs:recordData>
+              	<marc:record>
+		<marc:leader>00000ndd a2200000 u 4500</marc:leader>
+		<marc:controlfield tag="001">004641417</marc:controlfield>
+		<marc:controlfield tag="003">DE-633</marc:controlfield>
+		<marc:controlfield tag="005">20161205081635.0</marc:controlfield>
+		<marc:datafield tag="031" ind1=" " ind2=" ">
+			<marc:subfield code="a">1</marc:subfield>
+			<marc:subfield code="b">1</marc:subfield>
+			<marc:subfield code="c">1</marc:subfield>
+			<marc:subfield code="d">[without title].</marc:subfield>
+			<marc:subfield code="g">C-4</marc:subfield>
+			<marc:subfield code="m">Coro T</marc:subfield>
+			<marc:subfield code="n">bBEA</marc:subfield>
+			<marc:subfield code="o">3/4</marc:subfield>
+			<marc:subfield code="p">,8GA/4.B8B&#39;C,A/4B4-</marc:subfield>
+			<marc:subfield code="r">c</marc:subfield>
+			<marc:subfield code="t">Was verklärt im Sturmes Drang</marc:subfield>
+			<marc:subfield code="u">20042867</marc:subfield>
+			<marc:subfield code="2">pe</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="040" ind1=" " ind2=" ">
+			<marc:subfield code="a">DE-633</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="041" ind1=" " ind2=" ">
+			<marc:subfield code="a">ger</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="100" ind1="1" ind2=" ">
+			<marc:subfield code="a">Zelter, Carl Friedrich</marc:subfield>
+			<marc:subfield code="d">1758-1832</marc:subfield>
+			<marc:subfield code="0">98629</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="240" ind1="1" ind2="0">
+			<marc:subfield code="a">Was verklärt im Sturmes Drang</marc:subfield>
+			<marc:subfield code="m">coro</marc:subfield>
+			<marc:subfield code="r">c</marc:subfield>
+			<marc:subfield code="0">3917677</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="245" ind1="1" ind2="0">
+			<marc:subfield code="a">[without title]</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="260" ind1=" " ind2=" ">
+			<marc:subfield code="c">1815 (&quot;B 30 8br | 1815.&quot;)</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="300" ind1=" " ind2=" ">
+			<marc:subfield code="a">score: 1p. [p. 5]</marc:subfield>
+			<marc:subfield code="c">37 x 22 cm</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="592" ind1=" " ind2=" ">
+			<marc:subfield code="a">[not to identify]</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="593" ind1=" " ind2=" ">
+			<marc:subfield code="a">Autograph manuscript</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="b">Coro S</marc:subfield>
+			<marc:subfield code="c">1</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="b">Coro A</marc:subfield>
+			<marc:subfield code="c">1</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="b">Coro T</marc:subfield>
+			<marc:subfield code="c">2</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="b">Coro B</marc:subfield>
+			<marc:subfield code="c">1</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="a">Coro S, Coro A, Coro T (2), Coro B</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="650" ind1="0" ind2="0">
+			<marc:subfield code="a">Partsongs</marc:subfield>
+			<marc:subfield code="0">25460</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="773" ind1="0" ind2=" ">
+			<marc:subfield code="w">464141752</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="852" ind1=" " ind2=" ">
+			<marc:subfield code="a">D-B</marc:subfield>
+			<marc:subfield code="c">Mus.ms.autogr. Zelter, K. F. 17 (5)</marc:subfield>
+			<marc:subfield code="e">Staatsbibliothek zu Berlin - Preußischer Kulturbesitz, Musikabteilung</marc:subfield>
+			<marc:subfield code="x">30000655</marc:subfield>
+		</marc:datafield>
+	</marc:record>
+
+          </zs:recordData>
+          <zs:recordPosition>3</zs:recordPosition>
+        </zs:record>
+        <zs:record>
+          <zs:recordPacking>xml</zs:recordPacking>
+          <zs:recordData>
+              	<marc:record>
+		<marc:leader>00000ndd a2200000 u 4500</marc:leader>
+		<marc:controlfield tag="001">004641418</marc:controlfield>
+		<marc:controlfield tag="003">DE-633</marc:controlfield>
+		<marc:controlfield tag="005">20161205081636.0</marc:controlfield>
+		<marc:datafield tag="031" ind1=" " ind2=" ">
+			<marc:subfield code="a">1</marc:subfield>
+			<marc:subfield code="b">1</marc:subfield>
+			<marc:subfield code="c">1</marc:subfield>
+			<marc:subfield code="d">Munter und würdig.</marc:subfield>
+			<marc:subfield code="g">C-4</marc:subfield>
+			<marc:subfield code="m">Coro T</marc:subfield>
+			<marc:subfield code="o">3/4</marc:subfield>
+			<marc:subfield code="p">, 4E/GEE/GEG/4.F8G4F/ 4E4-</marc:subfield>
+			<marc:subfield code="r">C</marc:subfield>
+			<marc:subfield code="t">Ihr mystischen Zahlen Drei, Sieben und Neun</marc:subfield>
+			<marc:subfield code="u">20042877</marc:subfield>
+			<marc:subfield code="2">pe</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="040" ind1=" " ind2=" ">
+			<marc:subfield code="a">DE-633</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="041" ind1=" " ind2=" ">
+			<marc:subfield code="a">ger</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="100" ind1="1" ind2=" ">
+			<marc:subfield code="a">Zelter, Carl Friedrich</marc:subfield>
+			<marc:subfield code="d">1758-1832</marc:subfield>
+			<marc:subfield code="0">98629</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="240" ind1="1" ind2="0">
+			<marc:subfield code="a">Patriotisches Rheinweinlied der Elfer</marc:subfield>
+			<marc:subfield code="m">coro maschile</marc:subfield>
+			<marc:subfield code="r">C</marc:subfield>
+			<marc:subfield code="0">3917679</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="245" ind1="1" ind2="0">
+			<marc:subfield code="a">[caption title, p. 6:] [with pencil: &quot;No 10.&quot;] Rheinweinlied</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="260" ind1=" " ind2=" ">
+			<marc:subfield code="c">1815 (&quot;Berlin d 2 November | 1815&quot;)</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="300" ind1=" " ind2=" ">
+			<marc:subfield code="a">score: 2p. [p. 6-7]</marc:subfield>
+			<marc:subfield code="c">37 x 22 cm</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="500" ind1=" " ind2=" ">
+			<marc:subfield code="a">p. 7 Strophen 2-7 von der Hand Zelters, darunter die Datierung.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="592" ind1=" " ind2=" ">
+			<marc:subfield code="a">[not to identify]</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="593" ind1=" " ind2=" ">
+			<marc:subfield code="a">Autograph manuscript</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="b">Coro T</marc:subfield>
+			<marc:subfield code="c">2</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="b">Coro B</marc:subfield>
+			<marc:subfield code="c">2</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="a">Coro T (2), Coro B (2)</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="650" ind1="0" ind2="0">
+			<marc:subfield code="a">Partsongs</marc:subfield>
+			<marc:subfield code="0">25460</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="700" ind1="1" ind2=" ">
+			<marc:subfield code="a">Tismar, G.</marc:subfield>
+			<marc:subfield code="0">20002373</marc:subfield>
+			<marc:subfield code="4">lyr</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="730" ind1="0" ind2=" ">
+			<marc:subfield code="a">Ihr mystischen Zahlen Drei, Sieben und Neun</marc:subfield>
+			<marc:subfield code="g">RISM</marc:subfield>
+			<marc:subfield code="0">3917678</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="773" ind1="0" ind2=" ">
+			<marc:subfield code="w">464141752</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="852" ind1=" " ind2=" ">
+			<marc:subfield code="a">D-B</marc:subfield>
+			<marc:subfield code="c">Mus.ms.autogr. Zelter, K. F. 17 (6)</marc:subfield>
+			<marc:subfield code="e">Staatsbibliothek zu Berlin - Preußischer Kulturbesitz, Musikabteilung</marc:subfield>
+			<marc:subfield code="x">30000655</marc:subfield>
+		</marc:datafield>
+	</marc:record>
+
+          </zs:recordData>
+          <zs:recordPosition>4</zs:recordPosition>
+        </zs:record>
+        <zs:record>
+          <zs:recordPacking>xml</zs:recordPacking>
+          <zs:recordData>
+              	<marc:record>
+		<marc:leader>00000ndd a2200000 u 4500</marc:leader>
+		<marc:controlfield tag="001">046414174</marc:controlfield>
+		<marc:controlfield tag="003">DE-633</marc:controlfield>
+		<marc:controlfield tag="005">20161205081643.0</marc:controlfield>
+		<marc:datafield tag="031" ind1=" " ind2=" ">
+			<marc:subfield code="a">1</marc:subfield>
+			<marc:subfield code="b">1</marc:subfield>
+			<marc:subfield code="c">1</marc:subfield>
+			<marc:subfield code="d">Munter und gesanglich.</marc:subfield>
+			<marc:subfield code="g">C-4</marc:subfield>
+			<marc:subfield code="m">T</marc:subfield>
+			<marc:subfield code="n">xFC</marc:subfield>
+			<marc:subfield code="o">3/4</marc:subfield>
+			<marc:subfield code="p">,8.F6G4AA/8.B6A2G/&#39;8.D6C4DE/</marc:subfield>
+			<marc:subfield code="r">D</marc:subfield>
+			<marc:subfield code="t">Lauriger horatius quam dixit verum</marc:subfield>
+			<marc:subfield code="u">20042861</marc:subfield>
+			<marc:subfield code="2">pe</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="040" ind1=" " ind2=" ">
+			<marc:subfield code="a">DE-633</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="041" ind1=" " ind2=" ">
+			<marc:subfield code="a">lat</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="100" ind1="1" ind2=" ">
+			<marc:subfield code="a">Zelter, Carl Friedrich</marc:subfield>
+			<marc:subfield code="d">1758-1832</marc:subfield>
+			<marc:subfield code="0">98629</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="240" ind1="1" ind2="0">
+			<marc:subfield code="a">Lauriger Horatius</marc:subfield>
+			<marc:subfield code="m">V(3), coro maschile</marc:subfield>
+			<marc:subfield code="r">D</marc:subfield>
+			<marc:subfield code="0">3917684</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="245" ind1="1" ind2="0">
+			<marc:subfield code="a">[caption title, p. 2:] 15 febr 14.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="260" ind1=" " ind2=" ">
+			<marc:subfield code="c">1814</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="300" ind1=" " ind2=" ">
+			<marc:subfield code="a">score: 2p. [p. 2-3]</marc:subfield>
+			<marc:subfield code="c">34 x 21 cm</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="500" ind1=" " ind2=" ">
+			<marc:subfield code="a">Vor dem ersten System die Namen der solistisch singenden Männerstimmen: &quot;Langermann | Ritschel | Hartung&quot;.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="500" ind1=" " ind2=" ">
+			<marc:subfield code="a">Unter der letzten Akkolade eine Skizze von Zelters Hand mit Blei auf den Text &quot;Wer nie sein Brot mit Tränen aß&quot;.</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="592" ind1=" " ind2=" ">
+			<marc:subfield code="a">[letters in circle, countermark letters (not to identify)]</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="593" ind1=" " ind2=" ">
+			<marc:subfield code="a">Autograph manuscript</marc:subfield>
+			<marc:subfield code="8">01</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="b">T</marc:subfield>
+			<marc:subfield code="c">2</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="b">B</marc:subfield>
+			<marc:subfield code="c">1</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="b">Coro T</marc:subfield>
+			<marc:subfield code="c">2</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="b">Coro B</marc:subfield>
+			<marc:subfield code="c">1</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="594" ind1=" " ind2=" ">
+			<marc:subfield code="a">T (2), B, Coro T (2), Coro B</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="650" ind1="0" ind2="0">
+			<marc:subfield code="a">Partsongs</marc:subfield>
+			<marc:subfield code="0">25460</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="700" ind1="1" ind2=" ">
+			<marc:subfield code="a">Hoffmann von Fallersleben, August Heinrich</marc:subfield>
+			<marc:subfield code="d">1798-1874</marc:subfield>
+			<marc:subfield code="j">Ascertained</marc:subfield>
+			<marc:subfield code="0">95806</marc:subfield>
+			<marc:subfield code="4">lyr</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="700" ind1="1" ind2=" ">
+			<marc:subfield code="a">Langermann, Johann Gottfried</marc:subfield>
+			<marc:subfield code="d">1768-1832</marc:subfield>
+			<marc:subfield code="0">72725</marc:subfield>
+			<marc:subfield code="4">oth</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="773" ind1="0" ind2=" ">
+			<marc:subfield code="w">464141752</marc:subfield>
+		</marc:datafield>
+		<marc:datafield tag="852" ind1=" " ind2=" ">
+			<marc:subfield code="a">D-B</marc:subfield>
+			<marc:subfield code="c">Mus.ms.autogr. Zelter, K. F. 17 (2)</marc:subfield>
+			<marc:subfield code="e">Staatsbibliothek zu Berlin - Preußischer Kulturbesitz, Musikabteilung</marc:subfield>
+			<marc:subfield code="x">30000655</marc:subfield>
+		</marc:datafield>
+	</marc:record>
+
+          </zs:recordData>
+          <zs:recordPosition>5</zs:recordPosition>
+        </zs:record>
+    </zs:records>
+    <zs:echoedSearchRetrieveRequest>
+      <zs:version>1.1</zs:version>
+      <zs:query>bath.possessingInstitution=D-B</zs:query>
+      <zs:maximumRecords>5</zs:maximumRecords>
+      <zs:recordPacking>xml</zs:recordPacking>
+    </zs:echoedSearchRetrieveRequest>
+  </zs:searchRetrieveResponse>
+
+
+

--- a/t/namespace_prefix.t
+++ b/t/namespace_prefix.t
@@ -1,0 +1,46 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Test::Exception;
+use Catmandu::Importer::SRU;
+use Catmandu::Importer::SRU::Parser::marcxml;
+use lib ".";
+require 't/lib/MockFurl.pm';
+
+my %attrs = (
+    base         => 'http://www.unicat.be/sru',
+    query        => 'marcxml_ns_prefix.xml',
+    recordSchema => 'marcxml',
+    parser       => 'marcxml',
+    furl         => MockFurl->new,
+);
+
+my $importer = Catmandu::Importer::SRU->new(%attrs);
+my $records  = $importer->to_array();
+
+is scalar @{$records}, 5, 'marc has 5 records';
+
+ok exists $records->[0]->{_id},    'marc has _id';
+ok exists $records->[0]->{record}, 'marc has record';
+is_deeply $records->[0]->{record}->[0],
+    [ 'LDR', ' ', ' ', '_', '00000ndd a2200000 u 4500' ], 'marc has leader';
+is_deeply $records->[0]->{record}->[1],
+    [ '001', ' ', ' ', '_', '004641415' ], 'marc has controlfield';
+is_deeply $records->[0]->{record}->[-1],
+    [
+    '852',
+    ' ',
+    ' ',
+    'a',
+    'D-B',
+    'c',
+    'Mus.ms.autogr. Zelter, K. F. 17 (3)',
+    'e',
+    'Staatsbibliothek zu Berlin - Preußischer Kulturbesitz, Musikabteilung',
+    'x',
+    '30000655'
+    ],
+    'marc has datafield';
+
+done_testing;


### PR DESCRIPTION
Catmandu::Importer::SRU::Parser::marcxml doesn't support MARC XML records where namespace prefixes are used. A problem is that the namespace could be declared at top of the SRU response and not in the single MARC XML records which are passed to Catmandu::Importer::SRU::Parser::marcxml. So I used a hack to implement this: check if a prefix is used and add the namespace to the \<record\> element.