### PR TITLE
Importer limit

### DIFF
--- a/lib/Catmandu/Importer/SRU.pm
+++ b/lib/Catmandu/Importer/SRU.pm
@@ -34,6 +34,7 @@ has limit => (
     lazy => 1,
     default => sub { 10 }
 );
+has total => ( is => 'ro' );
 
 # internal stuff.
 has _currentRecordSet => (is => 'ro');
@@ -168,6 +169,15 @@ sub _hashify {
 sub url {
   my ($self) = @_;
 
+  my $limit = $self->limit;
+  my $start = $self->_start;
+  my $total = $self->total;
+  if ( is_natural( $total ) && ( $start - 1 + $limit ) > $total ) {
+
+    $limit = $total - ($start - 1);
+
+  }
+
   # construct the url
   my $url = $self->base;
   $url .= '?version=' . uri_escape($self->version);
@@ -175,8 +185,8 @@ sub url {
   $url .= '&query=' . uri_escape($self->query);
   $url .= '&recordSchema=' . uri_escape($self->recordSchema);
   $url .= '&sortKeys=' . uri_esacpe($self->sortKeys) if $self->sortKeys;
-  $url .= '&startRecord=' . uri_escape($self->_start);
-  $url .= '&maximumRecords=' . uri_escape($self->limit);
+  $url .= '&startRecord=' . uri_escape($start);
+  $url .= '&maximumRecords=' . uri_escape($limit);
 
   return $url;
 }

--- a/lib/Catmandu/Importer/SRU.pm
+++ b/lib/Catmandu/Importer/SRU.pm
@@ -335,6 +335,22 @@ base URL of the SRU server (required)
 
 CQL query (required)
 
+=item limit
+
+Number of records to fetch in one batch.
+
+Remember that records are fetched in batches, and not in one request.
+
+Set to C<10> by default.
+
+This is translated to maximumRecords in the background.
+
+=item total
+
+Total number of records this importer may return.
+
+Not set by default.
+
 =item recordSchema
 
 set to C<dc> by default

--- a/lib/Catmandu/Importer/SRU.pm
+++ b/lib/Catmandu/Importer/SRU.pm
@@ -98,7 +98,7 @@ sub _hashify {
   my $xc     = XML::LibXML::XPathContext->new( $root );
   $xc->registerNs("srw","http://www.loc.gov/zing/srw/");
   $xc->registerNs("d","http://www.loc.gov/zing/srw/diagnostic/");
-  
+
   my $diagnostics = {};
   my $meta;
   my $records     = {};
@@ -117,7 +117,7 @@ sub _hashify {
   } elsif ($self->_meta_get) {
       for ($xc->findnodes('/srw:searchRetrieveResponse')) {
         for ($xc->findnodes('./*', $_)) {
-          my $tagName = $_->tagName;
+          my $tagName = $_->localname;
           next if $tagName eq 'records';
           if($tagName eq 'echoedSearchRetrieveRequest' or $tagName eq 'extraResponseData') {
             my $key = $tagName;
@@ -127,8 +127,8 @@ sub _hashify {
                 if(defined $_->prefix) {
                     $xc->registerNs($_->prefix,$_->namespaceURI());
                 }
-                my $tagName = $_->tagName;
-                $meta->{$key}->{$tagName} = $xc->findvalue(".",$_);
+                my $subTagName = $_->localname;
+                $meta->{$key}->{$subTagName} = $xc->findvalue(".",$_);
               }
             }
           } else {
@@ -137,7 +137,7 @@ sub _hashify {
       }
     }
   }
-  
+
   if ($xc->exists('/srw:searchRetrieveResponse/srw:records')) {
       $records->{record} = [];
 

--- a/lib/Catmandu/Importer/SRU.pm
+++ b/lib/Catmandu/Importer/SRU.pm
@@ -279,6 +279,34 @@ sub generator {
     $self->_nextRecord;
   };
 }
+sub count {
+
+  my $self = $_[0];
+
+  my $url = $self->base
+    . '?version=' . uri_escape( $self->version )
+    . '&operation=' .uri_escape( $self->operation )
+    . '&query=' . uri_escape( $self->query )
+    . '&recordSchema=' . uri_escape( $self->recordSchema )
+    . '&maximumRecords=0';
+
+  # fetch the xml response and hashify it.
+  my $xml  = $self->_request( $url )->{content};
+  my $old_value = $self->{_meta_get};
+  $self->{_meta_get} = 1;
+  my $hash = $self->_hashify( $xml );
+  $self->{_meta_get} = $old_value;
+
+  # sru specific error checking.
+  if (exists $hash->{'diagnostics'}->{'diagnostic'}) {
+    for my $error (@{$hash->{'diagnostics'}->{'diagnostic'}}) {
+        warn 'SRU DIAGNOSTIC: ', $error->{'message'} , ' : ' , $error->{'details'};
+    }
+  }
+
+  int( $hash->{meta}->{numberOfRecords} );
+
+}
 
 =head1 NAME
 


### PR DESCRIPTION
What I changed:

* make the batch size configurable by adding the parameter "limit". The old hidden parameter _max_results is therefore replaced by limit. A batch size of 10 was too small anyway.
* add parameter "total" that limits the total returned number of records.
* the extraction of tag name should not use the prefixed tag names in the hash response "meta".
   e.g. http://sru.bibsys.no/search/biblio?version=1.1&operation=searchRetrieve&startRecord=1&maximumRecords=0&recordSchema=dc&query=video

   in this case you get "srw:numberOfRecords" in the hash "meta" instead of "numberOfRecords".

* document parameters "limit" and "total".
* override method count from Catmandu::Iterable. This makes it easy to inspect an SRU repo without fully downloading all matching records.