### PR TITLE
Disable HTTP proxy in t/Catmandu-Fix-search_sru.t

### DIFF
--- a/t/Catmandu-Fix-search_sru.t
+++ b/t/Catmandu-Fix-search_sru.t
@@ -9,6 +9,7 @@ my $pkg;
 BEGIN {
     $pkg = 'Catmandu::Fix::search_sru';
     use_ok $pkg;
+    $ENV{'http_proxy'} = '';
 }
 
 require_ok $pkg;


### PR DESCRIPTION
Ubuntu's autopkgtest infrastructure sets it, but not for accessing localhost.